### PR TITLE
Zb  cart quantities

### DIFF
--- a/src/cart/index.html
+++ b/src/cart/index.html
@@ -20,38 +20,7 @@
       <section class="products">
         <h2>My Cart</h2>
 
-        <ul class="product-list">
-          <!-- <li class="cart-card divider">
-            <a href="product_pages/marmot-ajax-3.html" class="cart-card__image">
-              <img
-                src="images/tents/marmot-ajax-tent-3-person-3-season-in-pale-pumpkin-terracotta~p~880rr_01~320.jpg"
-                alt="Marmot Ajax tent"
-              />
-            </a>
-            <a href="product_pages/marmot-ajax-3.html">
-              <h2 class="card__name">Marmot Ajax Tent - 3-Person, 3-Season</h2>
-            </a>
-            <p class="cart-card__color">Pale Pumpkin/Terracotta</p>
-            <p class="cart-card__quantity">qty: 1</p>
-            <p class="cart-card__price">$199.99</p>
-          </li>
-          <li class="cart-card divider">
-            <a href="product_pages/marmot-ajax-3.html" class="cart-card__image">
-              <img
-                src="images/tents/the-north-face-talus-tent-4-person-3-season-in-golden-oak-saffron-yellow~p~985rf_01~320.jpg"
-                alt="Talus Tent - 4-Person, 3-Season"
-              />
-            </a>
-            <a href="product_pages/marmot-ajax-3.html">
-              <h2 class="card__name">
-                The North Face Talus Tent - 4-Person, 3-Season
-              </h2></a
-            >
-            <p class="cart-card__color">Golden Oak/Saffron Yellow</p>
-            <p class="cart-card__quantity">qty: 1</p>
-            <p class="cart-card__price">$199.99</p>
-          </li> -->
-        </ul>
+        <ul class="product-list"></ul>
 
         <div class="cart-footer hide">
           <p class="cart-total">Total:</p>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -242,6 +242,8 @@ button {
   font-size: var(--small-font);
   /* max-height: 120px; */
   align-items: center;
+  width: 100%;
+  padding: 1rem;
 }
 
 .cart-card__image {
@@ -269,7 +271,6 @@ button {
   display: flex;
   flex-direction: column-reverse;
 }
-
 
 .cart-card__quantity button {
   display: inline;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -238,7 +238,7 @@ button {
 /* Start cart list card styles */
 .cart-card {
   display: grid;
-  grid-template-columns: 25% auto 15%;
+  grid-template-columns: 25% auto 20%;
   font-size: var(--small-font);
   /* max-height: 120px; */
   align-items: center;
@@ -266,6 +266,34 @@ button {
 .cart-card__quantity {
   grid-row: 1;
   grid-column: 3;
+  display: flex;
+  flex-direction: column-reverse;
+}
+
+
+.cart-card__quantity button {
+  display: inline;
+  background-color: var(--light-grey);
+  color: var(--dark-grey);
+  padding: 0;
+  width: 1rem;
+  text-align: center;
+  border: 1px solid var(--dark-grey);
+  border-radius: 3px;
+  box-shadow: inset -1px -1px var(--dark-grey);
+  align-self: center;
+}
+
+.cart-card__quantity button:active {
+  box-shadow: inset 0 -1px var(--dark-grey);
+  transform: translateY(2px);
+}
+
+.cart-card__quantity span {
+  text-align: center;
+  align-self: center;
+  padding: 0;
+  width: auto;
 }
 
 .cart-card__price {
@@ -316,7 +344,11 @@ button {
 
   .cart-card {
     font-size: inherit;
-    grid-template-columns: 150px auto 15%;
+    grid-template-columns: 150px auto 20%;
+  }
+
+  .cart-card__quantity {
+    flex-direction: row;
   }
 }
 

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,4 +1,8 @@
-import { getLocalStorage, loadHeaderFooter, setLocalStorage } from "./utils.mjs";
+import {
+  getLocalStorage,
+  loadHeaderFooter,
+  setLocalStorage,
+} from "./utils.mjs";
 
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
@@ -6,7 +10,9 @@ function renderCartContents() {
     cartItems && cartItems.length > 0
       ? cartItems.map((item) => cartItemTemplate(item))
       : [];
-  document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  htmlItems.forEach((element) => {
+    document.querySelector(".product-list").appendChild(element);
+  });
 
   // Show totals only if cart is not empty
   if (cartItems && cartItems.length > 0) {
@@ -15,20 +21,67 @@ function renderCartContents() {
 }
 
 function cartItemTemplate(item) {
-  const newItem = `<li class="cart-card divider">
-  <a href="#" class="cart-card__image">
-    <img
-      src="${item.Images ? item.Images.PrimaryMedium : item.Image}"
-      alt="${item.Name}"
-    />
-  </a>
-  <a href="#">
-    <h2 class="card__name">${item.Name}</h2>
-  </a>
-  <p class="cart-card__color">${item.Colors[0].ColorName}</p>
-  <p class="cart-card__quantity"><button id="subQty">-</button><span>${item.quantity}</span><button id="addQty">+</button></p>
-  <p class="cart-card__price">$${(item.FinalPrice * item.quantity).toFixed(2)}</p>
-</li>`;
+  const newItem = document.createElement("li");
+  newItem.className = "cart-card divider";
+  newItem.id = `product_${item.Id}`;
+
+  const prodLink = document.createElement("a");
+  prodLink.setAttribute("href", `/product_pages/index.html?product=${item.Id}`);
+  prodLink.classList.add("cart-card__image");
+
+  const prodImg = document.createElement("img");
+  prodImg.setAttribute(
+    "src",
+    item.Images ? item.Images.PrimaryMedium : item.Image,
+  );
+  prodImg.setAttribute("alt", item.Name);
+  prodLink.appendChild(prodImg);
+  newItem.appendChild(prodLink);
+
+  const prodLink2 = document.createElement("a");
+  prodLink2.setAttribute(
+    "href",
+    `/product_pages/index.html?product=${item.Id}`,
+  );
+
+  const prodName = document.createElement("h2");
+  prodName.classList.add("card__name");
+  prodName.textContent = item.Name;
+  prodLink2.append(prodName);
+  newItem.appendChild(prodLink2);
+
+  const prodColor = document.createElement("p");
+  prodColor.textContent = item.Colors[0].ColorName;
+  prodColor.className = "cart-card__color";
+  newItem.appendChild(prodColor);
+
+  const prodQty = document.createElement("p");
+  prodQty.className = "cart-card__quantity";
+
+  const subBtn = document.createElement("button");
+  subBtn.textContent = "-";
+  subBtn.addEventListener("click", () => {
+    subtractItem(item.Id);
+  });
+  prodQty.appendChild(subBtn);
+
+  const qty = document.createElement("span");
+  qty.textContent = item.quantity;
+  prodQty.appendChild(qty);
+
+  const addBtn = document.createElement("button");
+  addBtn.textContent = "+";
+  addBtn.addEventListener("click", () => {
+    addItem(item.Id);
+  });
+  prodQty.appendChild(addBtn);
+
+  newItem.appendChild(prodQty);
+
+  const prodPrice = document.createElement("p");
+  prodPrice.className = "cart-card__price";
+  prodPrice.textContent = (item.FinalPrice * item.quantity).toFixed(2);
+  newItem.appendChild(prodPrice);
 
   return newItem;
 }
@@ -46,11 +99,49 @@ function renderCartTotal(cartItems) {
 }
 
 function addItem(productId) {
+  const prodList = getLocalStorage("so-cart");
 
+  prodList.forEach((product) => {
+    if (product.Id === productId) {
+      //Add 1 to the product quantity and update the cart page and the local storage.
+      ++product.quantity;
+      setLocalStorage("so-cart", prodList);
+      document.querySelector(
+        `#product_${productId} p.cart-card__quantity span`,
+      ).textContent = product.quantity;
+      renderCartTotal(prodList);
+    }
+  });
 }
 
 function subtractItem(productId) {
-  
+  let prodList = getLocalStorage("so-cart");
+
+  prodList.forEach((product) => {
+    //Remove 1 from the product quantity.
+    if (product.Id === productId) {
+      --product.quantity;
+      if (product.quantity === 0) {
+        //If the product quantity is 0, remove it from the local storage list and the cart page.
+        prodList = prodList.filter((prod) => prod.Id != productId);
+        setLocalStorage("so-cart", prodList);
+        document.querySelector(`#product_${productId}`).remove();
+        if (prodList.length > 0) {
+          renderCartTotal(prodList);
+        } else {
+          //If there are no more items in the cart/local storage, remove the total.
+          document.querySelector(".cart-total").remove();
+        }
+      } else {
+        //If there is 1 or more of the item left, update the cart and local storage
+        setLocalStorage("so-cart", prodList);
+        document.querySelector(
+          `#product_${productId} p.cart-card__quantity span`,
+        ).textContent = product.quantity;
+        renderCartTotal(prodList);
+      }
+    }
+  });
 }
 
 renderCartContents();

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,4 +1,4 @@
-import { getLocalStorage, loadHeaderFooter } from "./utils.mjs";
+import { getLocalStorage, loadHeaderFooter, setLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
@@ -26,7 +26,7 @@ function cartItemTemplate(item) {
     <h2 class="card__name">${item.Name}</h2>
   </a>
   <p class="cart-card__color">${item.Colors[0].ColorName}</p>
-  <p class="cart-card__quantity">qty: ${item.quantity}</p>
+  <p class="cart-card__quantity"><button id="subQty">-</button><span>${item.quantity}</span><button id="addQty">+</button></p>
   <p class="cart-card__price">$${(item.FinalPrice * item.quantity).toFixed(2)}</p>
 </li>`;
 
@@ -43,6 +43,14 @@ function renderCartTotal(cartItems) {
   cartFooter.classList.remove("hide");
   cartFooter.querySelector(".cart-total").textContent =
     `Total: $${total.toFixed(2)}`;
+}
+
+function addItem(productId) {
+
+}
+
+function subtractItem(productId) {
+  
 }
 
 renderCartContents();

--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -109,6 +109,9 @@ function addItem(productId) {
       document.querySelector(
         `#product_${productId} p.cart-card__quantity span`,
       ).textContent = product.quantity;
+      document.querySelector(
+        `#product_${productId} p.cart-card__price`,
+      ).textContent = (product.FinalPrice * product.quantity).toFixed(2);
       renderCartTotal(prodList);
     }
   });
@@ -121,6 +124,9 @@ function subtractItem(productId) {
     //Remove 1 from the product quantity.
     if (product.Id === productId) {
       --product.quantity;
+      document.querySelector(
+        `#product_${productId} p.cart-card__price`,
+      ).textContent = (product.FinalPrice * product.quantity).toFixed(2);
       if (product.quantity === 0) {
         //If the product quantity is 0, remove it from the local storage list and the cart page.
         prodList = prodList.filter((prod) => prod.Id != productId);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,7 @@
 import { loadHeaderFooter } from "./utils.mjs";
+import Alert from "./Alert.mjs";
+
+const alerts = new Alert(document.querySelector("main"));
+alerts.renderAlerts();
 
 loadHeaderFooter();

--- a/src/js/product-listing.js
+++ b/src/js/product-listing.js
@@ -1,10 +1,6 @@
 import ProductData from "./ProductData.mjs";
 import ProductList from "./ProductList.mjs";
-import Alert from "./Alert.mjs";
 import { loadHeaderFooter, getParam } from "./utils.mjs";
-
-const alerts = new Alert(document.querySelector("main"));
-alerts.renderAlerts();
 
 const category = getParam("category");
 


### PR DESCRIPTION
Added +/- buttons to adjust the quantity of items in the cart.

I had to rework the cart-card item template to add event listeners for the buttons.

When the quantity of an item is changed, the so-cart array in local storage is updated with the new quantity, and the cart page is updated with the new quantity and total.  If the quantity of an item reaches 0, it is removed from the so-cart array in local storage, and its cart-card is removed from the cart.  If that removed item is the last in the cart, the total is also removed, reflecting the cart page's empty state.